### PR TITLE
[MSHARED-799] Change "Created-By" manifest entry value to be reproducible

### DIFF
--- a/src/main/java/org/apache/maven/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/archiver/MavenArchiver.java
@@ -36,6 +36,7 @@ import org.codehaus.plexus.interpolation.PrefixedPropertiesValueSource;
 import org.codehaus.plexus.interpolation.RecursionInterceptor;
 import org.codehaus.plexus.interpolation.StringSearchInterpolator;
 import org.codehaus.plexus.interpolation.ValueSource;
+import org.apache.maven.shared.utils.PropertyUtils;
 import org.apache.maven.shared.utils.StringUtils;
 
 import javax.lang.model.SourceVersion;
@@ -610,6 +611,8 @@ public class MavenArchiver
         // Create the manifest
         // ----------------------------------------------------------------------
 
+        archiver.setMinimalDefaultManifest( true );
+
         File manifestFile = archiveConfiguration.getManifestFile();
 
         if ( manifestFile != null )
@@ -665,14 +668,11 @@ public class MavenArchiver
     private void addCreatedByEntry( MavenSession session, Manifest m, Map<String, String> entries )
         throws ManifestException
     {
-        String createdBy = "Apache Maven";
-        if ( session != null ) // can be null due to API backwards compatibility
+        String createdBy = "Maven Archiver";
+        String archiverVersion = getArchiverVersion();
+        if ( archiverVersion != null )
         {
-            String mavenVersion = session.getSystemProperties().getProperty( "maven.version" );
-            if ( mavenVersion != null )
-            {
-                createdBy += " " + mavenVersion;
-            }
+            createdBy += " " + archiverVersion;
         }
         addManifestAttribute( m, entries, "Created-By", createdBy );
     }
@@ -703,4 +703,13 @@ public class MavenArchiver
         }
         return null;
     }
+
+    private static String getArchiverVersion()
+    {
+        final Properties properties = PropertyUtils.loadOptionalProperties( MavenArchiver.class.getResourceAsStream(
+            "/META-INF/maven/org.apache.maven/maven-archiver/pom.properties" ) );
+
+        return properties.getProperty( "version" );
+    }
+
 }

--- a/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
@@ -489,7 +489,8 @@ public class MavenArchiverTest
         assertTrue( jarFile.exists() );
         Attributes manifest = getJarFileManifest( jarFile ).getMainAttributes();
 
-        assertEquals( "Apache Maven", manifest.get( new Attributes.Name( "Created-By" ) ) ); // no version number
+        // no version number
+        assertEquals( "Maven Archiver", manifest.get( new Attributes.Name( "Created-By" ) ) );
 
         assertEquals( "archiver test", manifest.get( Attributes.Name.SPECIFICATION_TITLE ) );
         assertEquals( "0.1", manifest.get( Attributes.Name.SPECIFICATION_VERSION ) );
@@ -540,7 +541,8 @@ public class MavenArchiverTest
         final Manifest jarFileManifest = getJarFileManifest( jarFile );
         Attributes manifest = jarFileManifest.getMainAttributes();
 
-        assertEquals( "Apache Maven 3.0.4", manifest.get( new Attributes.Name( "Created-By" ) ) );
+        // no version number
+        assertEquals( "Maven Archiver", manifest.get( new Attributes.Name( "Created-By" ) ) );
 
         assertEquals( session.getSystemProperties().get( "maven.build.version" ),
             manifest.get( new Attributes.Name( "Build-Tool" ) ) );
@@ -600,30 +602,6 @@ public class MavenArchiverTest
         {
             assertEquals( "Invalid automatic module name: '123.in-valid.new.name'", e.getMessage() );
         }
-    }
-
-    @Test
-    public void testCreatedByManifestEntryWithoutMavenVersion()
-        throws Exception
-    {
-        File jarFile = new File( "target/test/dummy.jar" );
-        JarArchiver jarArchiver = getCleanJarArchiver( jarFile );
-
-        MavenArchiver archiver = getMavenArchiver( jarArchiver );
-
-        MavenSession session = getDummySessionWithoutMavenVersion();
-        MavenProject project = getDummyProject();
-
-        MavenArchiveConfiguration config = new MavenArchiveConfiguration();
-        config.setForced( true );
-
-        archiver.createArchive( session, project, config );
-        assertTrue( jarFile.exists() );
-
-        final Manifest manifest = getJarFileManifest( jarFile );
-        Map<Object, Object> entries = manifest.getMainAttributes();
-
-        assertEquals( "Apache Maven", entries.get( new Attributes.Name( "Created-By" ) ) );
     }
 
     /*


### PR DESCRIPTION
The test method testCreatedByManifestEntryWithoutMavenVersion() has been
dropped because its function is coverted by two other tests as well.