### PR TITLE
reproducible build: always encode pom.properties with unix lf instead of crlf even on windows

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="false" sync-formatter="false">
+  <local-check-config name="maven-checkstyle-plugin checkstyle-check" location="jar:file:/C:/Users/arnau/.m2/repository/org/apache/maven/shared/maven-shared-resources/2/maven-shared-resources-2.jar!/config/maven_checks.xml" type="remote" description="maven-checkstyle-plugin configuration checkstyle-check">
+    <property name="checkstyle.cache.file" value="${project_loc}/target/checkstyle-cachefile"/>
+    <property name="checkstyle.header.file" value="D:\arn\eclipse-ws\ws2019-06\.metadata\.plugins\org.eclipse.core.resources\.projects\maven-archiver-myfork\com.basistech.m2e.code.quality.checkstyleConfigurator\checkstyle-header-checkstyle-check.txt"/>
+  </local-check-config>
+  <fileset name="java-sources-checkstyle-check" enabled="true" check-config-name="maven-checkstyle-plugin checkstyle-check" local="true">
+    <file-match-pattern match-pattern="^src/main/java.*\.java" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/main/resources.*\.properties" include-pattern="true"/>
+    <file-match-pattern match-pattern="^src/test/resources/.*\.properties" include-pattern="true"/>
+  </fileset>
+</fileset-config>

--- a/src/main/java/org/apache/maven/archiver/PomPropertiesUtil.java
+++ b/src/main/java/org/apache/maven/archiver/PomPropertiesUtil.java
@@ -20,13 +20,16 @@ package org.apache.maven.archiver;
  */
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -87,7 +90,10 @@ public class PomPropertiesUtil
         {
             return;
         }
-        PrintWriter pw = new PrintWriter( outputFile, "ISO-8859-1" );
+
+        Writer output = new BufferedWriter( new OutputStreamWriter(
+            new FileOutputStream( outputFile ), "ISO-8859-1" ) );
+
         try
         {
             StringWriter sw = new StringWriter();
@@ -113,15 +119,16 @@ public class PomPropertiesUtil
             Collections.sort( lines );
             for ( String l : lines )
             {
-                pw.println( l );
+                output.write( l );
+                output.write( "\n" );
             }
 
-            pw.close();
-            pw = null;
+            output.close();
+            output = null;
         }
         finally
         {
-            IOUtil.close( pw );
+            IOUtil.close( output );
         }
     }
 


### PR DESCRIPTION
replaced PrintWriter by simply Writer, and use explicit   write("\n");

internally to class PrintWriter, there is
```
    protected Writer out;
    private final String lineSeparator;
    ..        lineSeparator = java.security.AccessController.doPrivileged(
            new sun.security.action.GetPropertyAction("line.separator"));
    ..    public void println(String x) {
        synchronized (lock) {
            print(x);
            println();
        }
    }

```
So it is better to use Writer directly
