### PR TITLE
[MSHARED-1088] Update Plexus IO 3.4.0 and Plexus Archiver 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-io</artifactId>
-      <version>3.3.2-SNAPSHOT</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-io</artifactId>
-      <version>3.3.1</version>
+      <version>3.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.2.7</version>
+      <version>4.3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.3.1-SNAPSHOT</version>
+      <version>4.4.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.4.0-SNAPSHOT</version>
+      <version>4.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Update two dependencies:
 * plexus-io 3.4.0
 * plexus-archiver 4.4.0 

They are now pure JSR330 components, so take care about (possibly obsolete) other dependencies as well.

---

https://issues.apache.org/jira/browse/MSHARED-1088


