### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.


### PR DESCRIPTION
Added a LICENSE file at the root level directory. The license are as per the pom.xml file (https://github.com/apache/maven-archiver/blob/master/pom.xml#L3C1-L17C21). The license is version 2.0 of the Apache License. This is required for Github API for license fetch works for this repository.

(Please note that the Copyright year and owner fields have been intentionally left empty since Google LLC doesn't own this repository)


