### PR TITLE
MSHARED-1430  [MJAR-314] Use the special constant value REPRODUCIBLE_BUILD_STATIC_DATE

### DIFF
--- a/src/main/java/org/apache/maven/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/archiver/MavenArchiver.java
@@ -101,6 +101,11 @@ public class MavenArchiver {
 
     private static final Instant DATE_MAX = Instant.parse("2099-12-31T23:59:59Z");
 
+    /**
+     * The special default time for reproducible builds that is also used by Gradle
+     */
+    private static final Instant REPRODUCIBLE_BUILD_STATIC_DATE = Instant.parse("1980-02-01T00:00:00Z");
+
     private static final List<String> ARTIFACT_EXPRESSION_PREFIXES;
 
     static {
@@ -679,6 +684,7 @@ public class MavenArchiver {
      *
      * <p>Either as {@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME} or as a number representing seconds
      * since the epoch (like <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     * Use the special constant value {@code "REPRODUCIBLE_BUILD_STATIC_DATE"} to set the default time i.e. 1980-02-01T00:00:00Z.
      *
      * @param outputTimestamp the value of {@code ${project.build.outputTimestamp}} (may be {@code null})
      * @return the parsed timestamp as an {@code Optional<Instant>}, {@code empty} if input is {@code null} or input
@@ -691,6 +697,9 @@ public class MavenArchiver {
         // Fail-fast on nulls
         if (outputTimestamp == null) {
             return Optional.empty();
+        }
+        if (outputTimestamp.equalsIgnoreCase("REPRODUCIBLE_BUILD_STATIC_DATE")) {
+            return Optional.of(REPRODUCIBLE_BUILD_STATIC_DATE);
         }
 
         // Number representing seconds since the epoch

--- a/src/test/java/org/apache/maven/archiver/ManifestConfigurationTest.java
+++ b/src/test/java/org/apache/maven/archiver/ManifestConfigurationTest.java
@@ -45,7 +45,7 @@ class ManifestConfigurationTest {
     }
 
     @Test
-    void getClasspathPrefixShouldReturnPrefixWithTraingSlash() {
+    void getClasspathPrefixShouldReturnPrefixWithTrailingSlash() {
         manifestConfiguration.setClasspathPrefix("const");
         assertThat(manifestConfiguration.getClasspathPrefix()).isEqualTo("const/");
     }

--- a/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
@@ -1281,7 +1281,8 @@ class MavenArchiverTest {
         "1988-02-22T15:23:47.76598Z,572541827",
         "2011-12-03T10:15:30+01:00,1322903730",
         "1980-01-01T00:00:02Z,315532802",
-        "2099-12-31T23:59:59Z,4102444799"
+        "2099-12-31T23:59:59Z,4102444799",
+        "REPRODUCIBLE_BUILD_STATIC_DATE,318211200"
     })
     void testParseOutputTimestampInstant(String value, long expected) {
         assertThat(MavenArchiver.parseBuildOutputTimestamp(value)).contains(Instant.ofEpochSecond(expected));


### PR DESCRIPTION
The Gradle has an option preserveFileTimestamps = false that will just put 1 Feb 1980 as a date in Zip archive.
 The 1 Jan 1980 is a minimal date in Zip archive but the 1 Jan has some special treatment by Java.
That's why the Gradle team used the 1 Feb.
Introduce a constant value for the outputTimestamp to make an intention clear but also easier to find an explanation for this.


https://issues.apache.org/jira/browse/MJAR-314 / https://issues.apache.org/jira/browse/MSHARED-1430


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHARED) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MSHARED-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHARED-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

