### PR TITLE
Treat empty Automatic-Module-Name as no Automatic-Module-Name at all

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -566,7 +566,9 @@ public class MavenArchiver {
         }
         String automaticModuleName = manifest.getMainSection().getAttributeValue("Automatic-Module-Name");
         if (automaticModuleName != null) {
-            if (!isValidModuleName(automaticModuleName)) {
+            if (automaticModuleName.isEmpty()) {
+                manifest.getMainSection().removeAttribute("Automatic-Module-Name");
+            } else if (!isValidModuleName(automaticModuleName)) {
                 throw new ManifestException("Invalid automatic module name: '" + automaticModuleName + "'");
             }
         }

--- a/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
@@ -473,6 +473,33 @@ class MavenArchiverTest {
         }
     }
 
+    /*
+     * Test to make sure that empty Automatic-Module-Name will result in no
+     * Automatic-Module-Name attribute at all, but that the archive will be created.
+     */
+    @Test
+    void testManifestWithEmptyAutomaticModuleName() throws Exception {
+        File jarFile = new File("target/test/dummy.jar");
+        JarArchiver jarArchiver = getCleanJarArchiver(jarFile);
+
+        MavenArchiver archiver = getMavenArchiver(jarArchiver);
+
+        Project project = getDummyProject();
+        MavenArchiveConfiguration config = new MavenArchiveConfiguration();
+
+        Map<String, String> manifestEntries = new HashMap<>();
+        manifestEntries.put("Automatic-Module-Name", "");
+        config.setManifestEntries(manifestEntries);
+
+        archiver.createArchive(session, project, config);
+        assertThat(jarFile).exists();
+
+        final Manifest jarFileManifest = getJarFileManifest(jarFile);
+        Attributes manifest = jarFileManifest.getMainAttributes();
+
+        assertThat(manifest).doesNotContainKey(new Attributes.Name("Automatic-Module-Name"));
+    }
+
     //
     // Test to make sure that manifest sections are present in the manifest prior to the archive has been created.
     //


### PR DESCRIPTION
There are projects out there that have &lt;Automatic-Module-Name/&gt; elements. In that case, let us consider it as no Automatic-Module-Name element at all.