### PR TITLE
Add tag-template to release-drafter configuration

### DIFF
--- a/.github/release-drafter-3.x.yml
+++ b/.github/release-drafter-3.x.yml
@@ -16,6 +16,4 @@
 # under the License.
 
 _extends: maven-gh-actions-shared:.github/release-drafter.yml
-
-filter-by-commitish: true
-commitish: maven-archiver-3.x
+tag-template: maven-archiver-$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,6 +16,7 @@
 # under the License.
 
 _extends: maven-gh-actions-shared
+tag-template: maven-archiver-$RESOLVED_VERSION
 
 include-pre-releases: true
 prerelease: true


### PR DESCRIPTION
Each maven project has a different tag name for release, so we need to configure it

