### PR TITLE
don't limit outputTimestamp to zip (MS DOS) range

### DIFF
--- a/src/main/java/org/apache/maven/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/archiver/MavenArchiver.java
@@ -97,10 +97,6 @@ public class MavenArchiver {
             "${artifact.groupIdPath}/${artifact.artifactId}/" + "${artifact.baseVersion}/${artifact.artifactId}-"
                     + "${artifact.baseVersion}${dashClassifier?}.${artifact.extension}";
 
-    private static final Instant DATE_MIN = Instant.parse("1980-01-01T00:00:02Z");
-
-    private static final Instant DATE_MAX = Instant.parse("2099-12-31T23:59:59Z");
-
     private static final List<String> ARTIFACT_EXPRESSION_PREFIXES;
 
     static {
@@ -756,10 +752,6 @@ public class MavenArchiver {
      * @return the parsed timestamp as an {@code Optional<Instant>}, {@code empty} if input is {@code null} or input
      *         contains only 1 character (not a number)
      * @since 3.6.0
-     * @throws IllegalArgumentException if the outputTimestamp is neither ISO 8601 nor an integer, or it's not within
-     *             the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z as defined by
-     *             <a href="https://pkwaredownloads.blob.core.windows.net/pem/APPNOTE.txt">ZIP application note</a>,
-     *             section 4.4.6.
      * @see <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=74682318">Maven Wiki "Reproducible/Verifiable
      *      Builds"</a>
      */
@@ -777,11 +769,6 @@ public class MavenArchiver {
         // Number representing seconds since the epoch
         if (isNumeric(outputTimestamp)) {
             final Instant date = Instant.ofEpochSecond(Long.parseLong(outputTimestamp));
-
-            if (date.isBefore(DATE_MIN) || date.isAfter(DATE_MAX)) {
-                throw new IllegalArgumentException(
-                        "'" + date + "' is not within the valid range " + DATE_MIN + " to " + DATE_MAX);
-            }
             return Optional.of(date);
         }
 
@@ -791,11 +778,6 @@ public class MavenArchiver {
                     .withOffsetSameInstant(ZoneOffset.UTC)
                     .truncatedTo(ChronoUnit.SECONDS)
                     .toInstant();
-
-            if (date.isBefore(DATE_MIN) || date.isAfter(DATE_MAX)) {
-                throw new IllegalArgumentException(
-                        "'" + date + "' is not within the valid range " + DATE_MIN + " to " + DATE_MAX);
-            }
             return Optional.of(date);
         } catch (DateTimeParseException pe) {
             throw new IllegalArgumentException(

--- a/src/main/java/org/apache/maven/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/archiver/MavenArchiver.java
@@ -715,8 +715,7 @@ public class MavenArchiver {
      * @return the parsed timestamp, may be <code>null</code> if <code>null</code> input or input contains only 1
      *         character
      * @since 3.5.0
-     * @throws IllegalArgumentException if the outputTimestamp is neither ISO 8601 nor an integer, or it's not within
-     *             the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
+     * @throws IllegalArgumentException if the outputTimestamp is neither ISO 8601 nor an integer
      * @deprecated Use {@link #parseBuildOutputTimestamp(String)} instead.
      */
     @Deprecated
@@ -752,6 +751,7 @@ public class MavenArchiver {
      * @return the parsed timestamp as an {@code Optional<Instant>}, {@code empty} if input is {@code null} or input
      *         contains only 1 character (not a number)
      * @since 3.6.0
+     * @throws IllegalArgumentException if the outputTimestamp is neither ISO 8601 nor an integer.
      * @see <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=74682318">Maven Wiki "Reproducible/Verifiable
      *      Builds"</a>
      */

--- a/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
@@ -1426,26 +1426,6 @@ class MavenArchiverTest {
     }
 
     @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "0",
-                "1",
-                "9",
-                "1980-01-01T00:00:01Z",
-                "2100-01-01T00:00Z",
-                "2100-02-28T23:59:59Z",
-                "2099-12-31T23:59:59-01:00",
-                "1980-01-01T00:15:35+01:00",
-                "1980-01-01T10:15:35+14:00"
-            })
-    void testThrownParseOutputTimestampInvalidRange(String outputTimestamp) {
-        // date is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> parseBuildOutputTimestamp(outputTimestamp))
-                .withMessageContaining("is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z");
-    }
-
-    @ParameterizedTest
     @CsvSource({
         "2011-12-03T10:15:30+01,1322903730",
         "2019-10-05T20:37:42+02,1570300662",


### PR DESCRIPTION
fixes #308 
drops check added in #22 and documented in #255

there is no reason to limit the value to something related to zip format: the timestamp may also be used for tar or any other archive format

failing a plugin for Reproducible Builds default timestamp value just creates a bad experience, that is really tricky to understand (default value of a plugin parameter injected from a property): if value has been defined with a value like "10", it's because user does not care about the effective timestamp in his archives, he just wants Reproducible Builds

let's keep things simple and not mix concerns: Reproducible Builds is about getting stable output, not a contract on precise zip entries timestamp