### PR TITLE
avoid negative entry time: upgrade plexus-archiver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.10.1</version>
+      <version>4.10.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/archiver/MavenArchiverTest.java
@@ -44,6 +44,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
@@ -1435,5 +1436,34 @@ class MavenArchiverTest {
     @EnabledForJreRange(min = JRE.JAVA_9)
     void testShortOffset(String value, long expected) {
         assertThat(parseBuildOutputTimestamp(value)).contains(Instant.ofEpochSecond(expected));
+    }
+
+    private long testReproducibleJarEntryTime(String name, String timestamp) throws Exception {
+        File jarFile = new File("target/test/dummy-" + name + ".jar");
+
+        MavenArchiver archiver = getMavenArchiver(getCleanJarArchiver(jarFile));
+        archiver.configureReproducibleBuild(timestamp);
+        archiver.createArchive(getDummySession(), getDummyProject(), new MavenArchiveConfiguration());
+
+        assertThat(jarFile).exists();
+        ZipFile zf = new ZipFile(jarFile);
+        ZipEntry ze = zf.getEntry("META-INF/MANIFEST.MF");
+        return ze.getTime();
+    }
+
+    /**
+     * before upgrading plexus archiver to 4.10.2 to benefit from https://github.com/codehaus-plexus/plexus-archiver/pull/388
+     * $ zipdetails target/test/dummy-1970.jar
+     * gives negative Extended Timestamp in Java, that is seen as some point in time in 2106 (zip spec is unsigned)
+     * 0027 Extra ID #0001        5455 'UT: Extended Timestamp'
+     * 0029   Length              0005
+     * 002B   Flags               '01 mod'
+     * 002C   Mod Time            FFFFF1FA 'Sun Feb  7 06:28:26 2106'
+     * @throws Exception
+     */
+    @Test
+    void testReproducibleJar19700101() throws Exception {
+        long entryTime = testReproducibleJarEntryTime("1970", "10");
+        assertThat(entryTime).isGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
benefit from https://github.com/codehaus-plexus/plexus-archiver/pull/388

to fix issue found in #313