### PR TITLE
avoid negative entry time: upgrade plexus-archiver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.10.1</version>
+      <version>4.10.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
cherry-picked #320
benefit from https://github.com/codehaus-plexus/plexus-archiver/pull/388
