### PR TITLE
fix: restrict `isNumeric()` to ASCII digits to prevent `NumberFormatExceptionRefactor` digit validation logic in MavenArchiver

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -717,7 +717,7 @@ public class MavenArchiver {
         }
 
         for (char c : str.toCharArray()) {
-            if (!Character.isDigit(c)) {
+            if (c < '0' || c > '9') {
                 return false;
             }
         }

--- a/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
@@ -1315,6 +1315,26 @@ class MavenArchiverTest {
     }
 
     @ParameterizedTest
+    @ValueSource(
+            strings = {
+                // Arabic-Indic digits (U+0660–U+0669)
+                "٠١٢٣٤٥٦٧٨٩",
+                // Bengali digits (U+09E6–U+09EF)
+                "০১২৩৪",
+                // Devanagari digits (U+0966–U+096F)
+                "०१२३४",
+                // Extended Arabic-Indic digits (U+06F0–U+06F9)
+                "۰۱۲۳۴"
+            })
+    void unicodeDigitsAreRejectedAsTimestamp(String unicodeDigits) {
+        // Character.isDigit() returns true for non-ASCII digits, but Long.parseLong() only accepts ASCII 0-9.
+        // These must not throw NumberFormatException — they must yield IAE with DateTimeParseException cause.
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> MavenArchiver.parseBuildOutputTimestamp(unicodeDigits))
+                .withCauseInstanceOf(DateTimeParseException.class);
+    }
+
+    @ParameterizedTest
     @CsvSource({
         "2011-12-03T10:15:30+01,1322903730",
         "2019-10-05T20:37:42+02,1570300662",


### PR DESCRIPTION
Fixes : #365

## Problem

The `isNumeric()` method currently uses `Character.isDigit()`, which returns `true` for many non-ASCII Unicode digits (such as Arabic-Indic `٠١٢٣`, Bengali `০১২৩`, and Devanagari `०१२३`).

When `parseBuildOutputTimestamp()` receives one of these values through `project.build.outputTimestamp` or `SOURCE_DATE_EPOCH`, `isNumeric()` incorrectly treats it as a valid numeric string. The value is then passed to `Long.parseLong()` (around line 697), which only accepts ASCII digits (`0–9`) and throws a `NumberFormatException`.

Since the method only catches `DateTimeParseException` (around line 708), the `NumberFormatException` propagates uncaught, causing archive creation to fail with an unhelpful error message.

## Fix

Replace the use of `Character.isDigit()` with an explicit ASCII digit check:

```java
c >= '0' && c <= '9'
```

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).