### PR TITLE
[MSHARED-815] Pattern.compile() called on every invocation of handleSpecificationEntries

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -99,6 +99,9 @@ public class MavenArchiver {
 
     private static final List<String> ARTIFACT_EXPRESSION_PREFIXES;
 
+    private static final Pattern SPECIFICATION_VERSION_PATTERN =
+            Pattern.compile("([0-9]+\\.[0-9]+)(.*?)");
+
     static {
         List<String> artifactExpressionPrefixes = new ArrayList<>();
         artifactExpressionPrefixes.add("artifact.");
@@ -413,7 +416,7 @@ public class MavenArchiver {
                 m, entries, "Specification-Title", project.getModel().getName());
 
         String version = project.getPomArtifact().getVersion().toString();
-        Matcher matcher = Pattern.compile("([0-9]+\\.[0-9]+)(.*?)").matcher(version);
+        Matcher matcher = SPECIFICATION_VERSION_PATTERN.matcher(version);
         if (matcher.matches()) {
             String specVersion = matcher.group(1);
             addManifestAttribute(m, entries, "Specification-Version", specVersion);

--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -99,8 +99,7 @@ public class MavenArchiver {
 
     private static final List<String> ARTIFACT_EXPRESSION_PREFIXES;
 
-    private static final Pattern SPECIFICATION_VERSION_PATTERN =
-            Pattern.compile("([0-9]+\\.[0-9]+)(.*?)");
+    private static final Pattern SPECIFICATION_VERSION_PATTERN = Pattern.compile("([0-9]+\\.[0-9]+)(.*?)");
 
     static {
         List<String> artifactExpressionPrefixes = new ArrayList<>();


### PR DESCRIPTION
Fixes #370

`Pattern.compile()` is called on every invocation of `handleSpecificationEntries()`, creating unnecessary GC pressure. This extracts the constant regex pattern to a `private static final Pattern` field.

No behavior change; pure optimization.