### PR TITLE
fix: throw NullPointerException when getManifest is called without Session and classpath is enabled

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -254,6 +254,10 @@ public class MavenArchiver {
 
         DependencyResolverResult result;
         if (config.isAddClasspath()) {
+            if (session == null) {
+                throw new NullPointerException("Session is required when addClasspath is enabled. "
+                        + "Use getManifest(Session, Project, ManifestConfiguration) instead.");
+            }
             result = session.getService(DependencyResolver.class).resolve(session, project, PathScope.MAIN_RUNTIME);
         } else {
             result = null;

--- a/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
@@ -98,6 +98,18 @@ class MavenArchiverTest {
         when(dependencyResolverResult.getDependencies()).thenReturn(dependencies);
     }
 
+    @Test
+    void getManifestWithoutSessionWhenAddClasspath() {
+        MavenArchiver archiver = new MavenArchiver();
+        Project project = getDummyProject();
+        ManifestConfiguration config = new ManifestConfiguration();
+        config.setAddClasspath(true);
+
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> archiver.getManifest(project, config))
+                .withMessageContaining("Session");
+    }
+
     @ParameterizedTest
     @EmptySource
     @ValueSource(


### PR DESCRIPTION
Fixes #364.

The two-parameter getManifest(Project, ManifestConfiguration) passes null for Session. When addClasspath or addExtensions is enabled, doGetManifest dereferences the null session, causing a NullPointerException.

Add a null check that throws an informative NullPointerException telling callers to use the three-parameter overload with a non-null Session.