### PR TITLE
Fix #371: Cache `model.getBuild()` result to avoid repeated calls

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/BuildHelper.java
+++ b/src/main/java/org/apache/maven/shared/archiver/BuildHelper.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.archiver;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.apache.maven.api.model.Build;
 import org.apache.maven.api.model.Model;
 import org.apache.maven.api.model.Plugin;
 import org.apache.maven.api.model.PluginContainer;
@@ -83,9 +84,10 @@ public class BuildHelper {
      * @return the plugin from build or pluginManagement, if available in project
      */
     public static Plugin getPlugin(Model model, String pluginGa) {
-        Plugin plugin = getPlugin(model.getBuild(), pluginGa);
-        if (model.getBuild() != null && plugin == null) {
-            plugin = getPlugin(model.getBuild().getPluginManagement(), pluginGa);
+        Build build = model.getBuild();
+        Plugin plugin = getPlugin(build, pluginGa);
+        if (build != null && plugin == null) {
+            plugin = getPlugin(build.getPluginManagement(), pluginGa);
         }
         return plugin;
     }


### PR DESCRIPTION
Fixes: #371 

Cache the result of `model.getBuild()` in a local variable instead of calling `getBuild()` multiple times. This avoids potential inconsistencies and prevents possible `NullPointerExceptions` when the Build instance changes between calls.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
