### PR TITLE
Skip unused dependency resolution for `addExtensions`

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
+++ b/src/main/java/org/apache/maven/shared/archiver/MavenArchiver.java
@@ -253,7 +253,7 @@ public class MavenArchiver {
         }
 
         DependencyResolverResult result;
-        if (config.isAddClasspath() || config.isAddExtensions()) {
+        if (config.isAddClasspath()) {
             result = session.getService(DependencyResolver.class).resolve(session, project, PathScope.MAIN_RUNTIME);
         } else {
             result = null;

--- a/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
+++ b/src/test/java/org/apache/maven/shared/archiver/MavenArchiverTest.java
@@ -76,6 +76,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MavenArchiverTest {
@@ -1434,5 +1436,24 @@ class MavenArchiverTest {
     void reproducibleJar19700101() throws Exception {
         long entryTime = testReproducibleJarEntryTime("1970", "10");
         assertThat(entryTime).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void addExtensionsAloneDoesNotTriggerDependencyResolution() throws Exception {
+        MavenArchiver archiver = new MavenArchiver();
+
+        ProjectStub project = new ProjectStub();
+        project.setModel(Model.newBuilder().artifactId("dummy").build());
+
+        ManifestConfiguration manifestConfig = new ManifestConfiguration();
+        manifestConfig.setAddExtensions(true);
+        manifestConfig.setAddClasspath(false);
+
+        MavenArchiveConfiguration archiveConfiguration = new MavenArchiveConfiguration();
+        archiveConfiguration.setManifest(manifestConfig);
+
+        archiver.getManifest(session, project, archiveConfiguration);
+
+        verify(dependencyResolver, never()).resolve(any(), any(Project.class), any());
     }
 }


### PR DESCRIPTION
Fixes : #369 

**Fix**

Restrict dependency resolution to the `addClasspath` path only.

Previously, dependency resolution was triggered when either `addClasspath` or `addExtensions` was enabled, even though the resolved dependencies were only used for `addClasspath`. This change removes the unnecessary resolution when only `addExtensions` is enabled, avoiding wasted work. A regression test has also been added to verify the behavior.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
