### PR TITLE
fix: prevent NPE in ManifestConfiguration.getClasspathPrefix() when prefix is null

### DIFF
--- a/src/main/java/org/apache/maven/shared/archiver/ManifestConfiguration.java
+++ b/src/main/java/org/apache/maven/shared/archiver/ManifestConfiguration.java
@@ -218,7 +218,7 @@ public class ManifestConfiguration {
      * @param classpathPrefix the prefix
      */
     public void setClasspathPrefix(String classpathPrefix) {
-        this.classpathPrefix = classpathPrefix;
+        this.classpathPrefix = classpathPrefix != null ? classpathPrefix : "";
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/archiver/ManifestConfigurationTest.java
+++ b/src/test/java/org/apache/maven/shared/archiver/ManifestConfigurationTest.java
@@ -55,4 +55,10 @@ class ManifestConfigurationTest {
         manifestConfiguration.setClasspathPrefix("const/");
         assertThat(manifestConfiguration.getClasspathPrefix()).isEqualTo("const/");
     }
+
+    @Test
+    void getClasspathPrefixShouldHandleNull() {
+        manifestConfiguration.setClasspathPrefix(null);
+        assertThat(manifestConfiguration.getClasspathPrefix()).isEmpty();
+    }
 }


### PR DESCRIPTION
Fixes #367.

**Problem:** `ManifestConfiguration.getClasspathPrefix()` calls `.replaceAll()` on the field without a null check. The field is initialized to `""`, but the setter stores the value as-is. If any caller passes `null` (e.g., from unset XML configuration elements mapped via Plexus), the getter throws NPE.

**Fix:** Guard `setClasspathPrefix()` against null, falling back to `""`.

**Test:** Added `getClasspathPrefixShouldHandleNull()`.